### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/esfak470639/5d0aa7b3-fe03-4864-86fd-86cb15997204/2c62b85b-22e1-480f-a023-6964c1719fe4/_apis/work/boardbadge/cff0976a-7f6f-448f-8a01-355e1d603e16)](https://dev.azure.com/esfak470639/5d0aa7b3-fe03-4864-86fd-86cb15997204/_boards/board/t/2c62b85b-22e1-480f-a023-6964c1719fe4/Microsoft.RequirementCategory)
 # plum
 Plum is open source blog system.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/esfak470639/5d0aa7b3-fe03-4864-86fd-86cb15997204/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.